### PR TITLE
Fix bugs in test.c file

### DIFF
--- a/lwrb/test/test.c
+++ b/lwrb/test/test.c
@@ -117,17 +117,17 @@ void basic_read_and_write(lwrb_t *buff, uint8_t *data_to_write, size_t data_size
     ret = lwrb_is_ready(buff);
     TEST_ASSERT_EQUAL(1, ret);
 
-    size_t  n_written = lwrb_write(buff, data_to_write, sizeof(data_to_write));
-    TEST_ASSERT_EQUAL(sizeof(data_to_write), n_written);
+    size_t  n_written = lwrb_write(buff, data_to_write, data_size);
+    TEST_ASSERT_EQUAL(data_size, n_written);
 
     size_t n_bytes_in_queue = lwrb_get_full(buff);
     TEST_ASSERT_EQUAL(n_written, n_bytes_in_queue);
 
-    uint8_t read_buffer[sizeof(data_to_write)];
+    uint8_t read_buffer[data_size];
     size_t n_read = lwrb_read(buff, read_buffer, n_bytes_in_queue);
     TEST_ASSERT_EQUAL(n_bytes_in_queue, n_read);
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(data_to_write, read_buffer, sizeof(data_to_write));
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data_to_write, read_buffer, data_size);
 
     free(buff_data);
 }


### PR DESCRIPTION
Hi,

I found a bug in the `basic_read_and_write function()`. The `data_to_write` variable has degenerated into a pointer in the function, so `sizeof(data_to_write)` will be 4 or 8 depending on the operating system. It doesn't represent the length of the data. I change it to `data_size`.