### PR TITLE
library.json: fix build in PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -31,5 +31,9 @@
 			"build",
 			"**/build"
 		]
+	},
+	"build": {
+		"includeDir": "lwrb/src/include",
+		"srcDir": "lwrb/src/lwrb"
 	}
 }


### PR DESCRIPTION
The defaults for `.build.{include,src}Dir` do not match the layout of the project, causing PlatformIO to invoke compiler on all source files, including those in `dev/` and `docs/`, which will fail.

Defining `.build.includeDir` and `.build.srcDir` to fix library build in PlatformIO.