### PR TITLE
lwrb.{h,c}: make atomic operations optional

### DIFF
--- a/lwrb/src/include/lwrb/lwrb.h
+++ b/lwrb/src/include/lwrb/lwrb.h
@@ -47,11 +47,11 @@ extern "C" {
  * \{
  */
 
-#ifdef __cplusplus
-typedef unsigned long lwrb_atomic_ulong_t;
+#ifdef LWRB_DISABLE_ATOMIC
+typedef unsigned long lwrb_ulong_t;
 #else
 #include <stdatomic.h>
-typedef atomic_ulong lwrb_atomic_ulong_t;
+typedef atomic_ulong lwrb_ulong_t;
 #endif
 
 /**
@@ -80,13 +80,10 @@ typedef void (*lwrb_evt_fn)(struct lwrb* buff, lwrb_evt_type_t evt, size_t bp);
  * \brief           Buffer structure
  */
 typedef struct lwrb {
-    uint8_t* buff; /*!< Pointer to buffer data.
-                                                    Buffer is considered initialized when `buff != NULL` and `size > 0` */
-    size_t size;   /*!< Size of buffer data. Size of actual buffer is `1` byte less than value holds */
-    lwrb_atomic_ulong_t
-        r; /*!< Next read pointer. Buffer is considered empty when `r == w` and full when `w == r - 1` */
-    lwrb_atomic_ulong_t
-        w;              /*!< Next write pointer. Buffer is considered empty when `r == w` and full when `w == r - 1` */
+    uint8_t* buff;  /*!< Pointer to buffer data. Buffer is considered initialized when `buff != NULL` and `size > 0` */
+    size_t size;    /*!< Size of buffer data. Size of actual buffer is `1` byte less than value holds */
+    lwrb_ulong_t r; /*!< Next read pointer. Buffer is considered empty when `r == w` and full when `w == r - 1` */
+    lwrb_ulong_t w; /*!< Next write pointer. Buffer is considered empty when `r == w` and full when `w == r - 1` */
     lwrb_evt_fn evt_fn; /*!< Pointer to event callback function */
 } lwrb_t;
 

--- a/lwrb/src/lwrb/lwrb.c
+++ b/lwrb/src/lwrb/lwrb.c
@@ -64,8 +64,13 @@ lwrb_init(lwrb_t* buff, void* buffdata, size_t size) {
     buff->evt_fn = NULL;
     buff->size = size;
     buff->buff = buffdata;
+#ifdef LWRB_DISABLE_ATOMIC
+    buff->w = 0;
+    buff->r = 0;
+#else
     atomic_init(&buff->w, 0);
     atomic_init(&buff->r, 0);
+#endif
     return 1;
 }
 
@@ -130,7 +135,11 @@ lwrb_write(lwrb_t* buff, const void* data, size_t btw) {
     if (btw == 0) {
         return 0;
     }
+#ifdef LWRB_DISABLE_ATOMIC
+    buff_w_ptr = buff->w;
+#else
     buff_w_ptr = atomic_load_explicit(&buff->w, memory_order_acquire);
+#endif
 
     /* Step 1: Write data to linear part of buffer */
     tocopy = BUF_MIN(buff->size - buff_w_ptr, btw);
@@ -153,7 +162,11 @@ lwrb_write(lwrb_t* buff, const void* data, size_t btw) {
      * Write final value to the actual running variable.
      * This is to ensure no read operation can access intermediate data
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    buff->w = buff_w_ptr;
+#else
     atomic_store_explicit(&buff->w, buff_w_ptr, memory_order_release);
+#endif
 
     BUF_SEND_EVT(buff, LWRB_EVT_WRITE, tocopy + btw);
     return tocopy + btw;
@@ -183,7 +196,11 @@ lwrb_read(lwrb_t* buff, void* data, size_t btr) {
     if (btr == 0) {
         return 0;
     }
+#ifdef LWRB_DISABLE_ATOMIC
+    buff_r_ptr = buff->r;
+#else
     buff_r_ptr = atomic_load_explicit(&buff->r, memory_order_acquire);
+#endif
 
     /* Step 1: Read data from linear part of buffer */
     tocopy = BUF_MIN(buff->size - buff_r_ptr, btr);
@@ -206,7 +223,11 @@ lwrb_read(lwrb_t* buff, void* data, size_t btr) {
      * Write final value to the actual running variable.
      * This is to ensure no write operation can access intermediate data
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    buff->r = buff_r_ptr;
+#else
     atomic_store_explicit(&buff->r, buff_r_ptr, memory_order_release);
+#endif
 
     BUF_SEND_EVT(buff, LWRB_EVT_READ, tocopy + btr);
     return tocopy + btr;
@@ -237,7 +258,11 @@ lwrb_peek(const lwrb_t* buff, size_t skip_count, void* data, size_t btp) {
     if (skip_count >= full) {
         return 0;
     }
+#ifdef LWRB_DISABLE_ATOMIC
+    r = buff->r;
+#else
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
     r += skip_count;
     full -= skip_count;
     if (r >= buff->size) {
@@ -280,21 +305,26 @@ lwrb_get_free(const lwrb_t* buff) {
      *
      * To ensure thread safety (only when in single-entry, single-exit FIFO mode use case),
      * it is important to write buffer r and w values to local w and r variables.
-     * 
+     *
      * Local variables will ensure below if statements will always use the same value,
      * even if buff->w or buff->r get changed during interrupt processing.
-     * 
+     *
      * They may change during load operation, important is that
      * they do not change during if-elseif-else operations following these assignments.
-     * 
+     *
      * lwrb_get_free is only called for write purpose, and when in FIFO mode, then:
      * - buff->w pointer will not change by another process/interrupt because we are in write mode just now
      * - buff->r pointer may change by another process. If it gets changed after buff->r has been loaded to local variable,
      *    buffer will see "free size" less than it actually is. This is not a problem, application can
      *    always try again to write more data to remaining free memory that was read just during copy operation
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    w = buff->w;
+    r = buff->r;
+#else
     w = atomic_load_explicit(&buff->w, memory_order_relaxed);
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
 
     if (w == r) {
         size = buff->size;
@@ -326,21 +356,26 @@ lwrb_get_full(const lwrb_t* buff) {
      *
      * To ensure thread safety (only when in single-entry, single-exit FIFO mode use case),
      * it is important to write buffer r and w values to local w and r variables.
-     * 
+     *
      * Local variables will ensure below if statements will always use the same value,
      * even if buff->w or buff->r get changed during interrupt processing.
-     * 
+     *
      * They may change during load operation, important is that
      * they do not change during if-elseif-else operations following these assignments.
-     * 
+     *
      * lwrb_get_full is only called for read purpose, and when in FIFO mode, then:
      * - buff->r pointer will not change by another process/interrupt because we are in read mode just now
      * - buff->w pointer may change by another process. If it gets changed after buff->w has been loaded to local variable,
      *    buffer will see "full size" less than it really is. This is not a problem, application can
      *    always try again to read more data from remaining full memory that was written just during copy operation
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    w = buff->w;
+    r = buff->r;
+#else
     w = atomic_load_explicit(&buff->w, memory_order_relaxed);
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
 
     if (w == r) {
         size = 0;
@@ -361,8 +396,13 @@ lwrb_get_full(const lwrb_t* buff) {
 void
 lwrb_reset(lwrb_t* buff) {
     if (BUF_IS_VALID(buff)) {
+#ifdef LWRB_DISABLE_ATOMIC
+        buff->w = 0;
+        buff->r = 0;
+#else
         atomic_store_explicit(&buff->w, 0, memory_order_release);
         atomic_store_explicit(&buff->r, 0, memory_order_release);
+#endif
         BUF_SEND_EVT(buff, LWRB_EVT_RESET, 0);
     }
 }
@@ -398,8 +438,14 @@ lwrb_get_linear_block_read_length(const lwrb_t* buff) {
      * Use temporary values in case they are changed during operations.
      * See lwrb_buff_free or lwrb_buff_full functions for more information why this is OK.
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    w = buff->w;
+    r = buff->r;
+#else
     w = atomic_load_explicit(&buff->w, memory_order_relaxed);
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
+
     if (w > r) {
         len = w - r;
     } else if (r > w) {
@@ -429,12 +475,20 @@ lwrb_skip(lwrb_t* buff, size_t len) {
 
     full = lwrb_get_full(buff);
     len = BUF_MIN(len, full);
+#ifdef LWRB_DISABLE_ATOMIC
+    r = buff->r;
+#else
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
     r += len;
     if (r >= buff->size) {
         r -= buff->size;
     }
+#ifdef LWRB_DISABLE_ATOMIC
+    buff->r = r;
+#else
     atomic_store_explicit(&buff->r, r, memory_order_release);
+#endif
     BUF_SEND_EVT(buff, LWRB_EVT_READ, len);
     return len;
 }
@@ -470,8 +524,14 @@ lwrb_get_linear_block_write_length(const lwrb_t* buff) {
      * Use temporary values in case they are changed during operations.
      * See lwrb_buff_free or lwrb_buff_full functions for more information why this is OK.
      */
+#ifdef LWRB_DISABLE_ATOMIC
+    w = buff->w;
+    r = buff->r;
+#else
     w = atomic_load_explicit(&buff->w, memory_order_relaxed);
     r = atomic_load_explicit(&buff->r, memory_order_relaxed);
+#endif
+
     if (w >= r) {
         len = buff->size - w;
         /*
@@ -514,12 +574,20 @@ lwrb_advance(lwrb_t* buff, size_t len) {
     /* Use local variables before writing back to main structure */
     free = lwrb_get_free(buff);
     len = BUF_MIN(len, free);
+#ifdef LWRB_DISABLE_ATOMIC
+    w = buff->w;
+#else
     w = atomic_load_explicit(&buff->w, memory_order_relaxed);
+#endif
     w += len;
     if (w >= buff->size) {
         w -= buff->size;
     }
+#ifdef LWRB_DISABLE_ATOMIC
+    buff->w = w;
+#else
     atomic_store_explicit(&buff->w, w, memory_order_release);
+#endif
     BUF_SEND_EVT(buff, LWRB_EVT_WRITE, len);
     return len;
 }


### PR DESCRIPTION
There are a few reasons for not using atomics in LwRB:

- Some targets do not have a proper libatomic implementation (for example, AVR). Compiling to these platforms will produce symbol undefined errors.
- When no MT-safety is required, or there is already a locking mechanism guaranteeing exclusive accesses, the use of atomic data types is not required.

This commit introduces macro LWRB_DISABLE_ATOMIC for controlling the use of C11 atomic data types. Defining the macro opts out the use of C11 atomics. LwRB still by default uses C11 atomics.