### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 
 # Setup project
-project(LwLibPROJECT)
+project(LwLibPROJECT C)
 
 if(NOT PROJECT_IS_TOP_LEVEL)
     add_subdirectory(lwrb)


### PR DESCRIPTION
lwrb is written in c, so only enforce a c compiler

Seen while compiling fluent-bit on buildroot.