### PR TITLE
Fix a small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Library provides generic FIFO ring buffer implementation.
 * Uses optimized memory copy instead of loops to read/write data from/to memory
 * Thread safe when used as pipe with single write and single read entries - when CPU read/write operation for `size_t` are single instruction (ARM Cortex-M for instance)
 * Interrupt safe when used as pipe with single write and single read entries - when CPU read/write operation for `size_t` are single instruction (ARM Cortex-M for instance)
-* For CPU systems with smaller achitecture than `sizeof(size_t)` (AVR for instance), atomic protection is required for read-write operation of buffer writes
+* For CPU systems with smaller architecture than `sizeof(size_t)` (AVR for instance), atomic protection is required for read-write operation of buffer writes
 * Suitable for DMA transfers from and to memory with zero-copy overhead between buffer and application memory
 * Supports data peek, skip for read and advance for write
 * Implements support for event notifications
@@ -21,7 +21,7 @@ Library provides generic FIFO ring buffer implementation.
 
 ## Contribute
 
-Fresh contributions are always welcome. Simple instructions to proceed::
+Fresh contributions are always welcome. Simple instructions to proceed:
 
 1. Fork Github repository
 2. Follow [C style & coding rules](https://github.com/MaJerle/c-code-style) already used in the project


### PR DESCRIPTION
`achitecture` ➡️ `architecture`